### PR TITLE
Don't unify Dynamic with anything other than Dynamic

### DIFF
--- a/src/tink/typecrawler/Crawler.hx
+++ b/src/tink/typecrawler/Crawler.hx
@@ -207,9 +207,15 @@ class Crawler {
     return ret;
   }
   
-  static function typesEquivalent(t1, t2)
-    return Context.unify(t1, t2) && Context.unify(t2, t1);
-
+  static function typesEquivalent(t1, t2) {
+    return switch [t1, t2] {
+      case [TDynamic(null), TDynamic(null)]: true;
+      case [TDynamic(null), _]: false;
+      case [_, TDynamic(null)]: false;
+      default: Context.unify(t1, t2) && Context.unify(t2, t1);
+    }
+  }
+  
   static public function typesEqual(t1, t2)
     return typesEquivalent(t1, t2);//TODO: make this more exact
   


### PR DESCRIPTION
The current behavior unifies Dynamic (`TDynamic(null)`) with anything, causing Dynamic to use the first item in the cache, which is wrong.

This fix makes sure Dynamic gets into the `rescue` branch correctly.


Should close https://github.com/haxetink/tink_validation/issues/4